### PR TITLE
Fix a compile error relating to including the C standard library and more

### DIFF
--- a/include/array.h
+++ b/include/array.h
@@ -11,8 +11,8 @@
  *
  * (c) Copyright Clifford Heath 2023. See LICENSE file for usage rights.
  */
-#include	<stdlib.h>
-#include	<stdint.h>
+#include	<cstdlib>
+#include	<cstdint>
 #include	<functional>
 
 #include	<refcount.h>

--- a/include/char_encoding.h
+++ b/include/char_encoding.h
@@ -38,7 +38,7 @@
  * (c) Copyright Clifford Heath 2022. See LICENSE file for usage rights.
  */
 #include	<assert.h>
-#include	<stdint.h>
+#include	<cstdint>
 
 typedef char		UTF8;		// We don't assume un/signed
 typedef uint16_t	UTF16;		// Used in Unicode 2, and 3 with surrogates

--- a/include/error.h
+++ b/include/error.h
@@ -26,7 +26,7 @@
  *
  * (c) Copyright Clifford Heath 2023. See LICENSE file for usage rights.
  */
-#include	<stdint.h>
+#include	<cstdint>
 #include	<limits.h>
 #include	<errno.h>
 #if     defined(MSW)

--- a/include/peg.h
+++ b/include/peg.h
@@ -1,4 +1,4 @@
-#include	<stdio.h>
+#include	<cstdio>
 #if !defined(PEG_H)
 #define PEG_H
 /*
@@ -6,8 +6,8 @@
  *
  * Copyright 2022 Clifford Heath. ALL RIGHTS RESERVED SUBJECT TO ATTACHED LICENSE.
  */
-#include	<stdlib.h>
-#include	<string.h>
+#include	<cstdlib>
+#include	<cstring>
 #include	<pegexp.h>
 #include	<vector>
 

--- a/include/pegexp.h
+++ b/include/pegexp.h
@@ -55,8 +55,8 @@
  *
  * (c) Copyright Clifford Heath 2023. See LICENSE file for usage rights.
  */
-#include	<stdint.h>
-#include	<stdlib.h>
+#include	<cstdint>
+#include	<cstdlib>
 #include	<ctype.h>
 #include	<char_encoding.h>
 

--- a/include/strpp.h
+++ b/include/strpp.h
@@ -14,8 +14,8 @@
  *
  * (c) Copyright Clifford Heath 2022. See LICENSE file for usage rights.
  */
-#include	<stdlib.h>
-#include	<stdint.h>
+#include	<cstdlib>
+#include	<cstdint>
 #include	<functional>
 
 #include	<refcount.h>

--- a/include/strval.h
+++ b/include/strval.h
@@ -14,8 +14,9 @@
  *
  * (c) Copyright Clifford Heath 2022. See LICENSE file for usage rights.
  */
-#include	<stdlib.h>
-#include	<stdint.h>
+#include	<cstdlib>
+#include	<cstdint>
+#include	<cstring>
 #include	<functional>
 #include	<type_traits>
 

--- a/src/rxcompile.cpp
+++ b/src/rxcompile.cpp
@@ -5,7 +5,7 @@
  * (c) Copyright Clifford Heath 2022. See LICENSE file for usage rights.
  */
 #include	<strregex.h>
-#include	<string.h>
+#include	<cstring>
 
 /*
  * Structure of the virtual machine:

--- a/src/rxdump.cpp
+++ b/src/rxdump.cpp
@@ -5,7 +5,8 @@
  * (c) Copyright Clifford Heath 2022. See LICENSE file for usage rights.
  */
 #include	<strregex.h>
-#include	<string.h>
+#include	<cstring>
+#include    <cstdio>
 
 void
 RxCompiler::dump(const char* nfa) const		// Dump NFA to stdout

--- a/src/rxmatch.cpp
+++ b/src/rxmatch.cpp
@@ -5,7 +5,7 @@
  * (c) Copyright Clifford Heath 2022. See LICENSE file for usage rights.
  */
 #include	<strregex.h>
-#include	<string.h>
+#include	<cstring>
 #include	<utility>
 
 #ifdef	TRACK_RESULTS

--- a/src/strpp.cpp
+++ b/src/strpp.cpp
@@ -16,9 +16,9 @@
  */
 #include	<strpp.h>
 
-#include	<string.h>
+#include	<cstring>
 #include	<limits.h>
-#include	<stdio.h>
+#include	<cstdio>
 
 StrBody		StrBody::nullBody("", false, 0, 0);
 const StrVal	StrVal::null;


### PR DESCRIPTION
Several small changes such as including `cstdio` when printf is used and also changing includes like `#include <stdio.h>` to `#include <cstdio>` which is the preferred method in C++